### PR TITLE
cargocms-laravel-element to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,12 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.89
+- name: cargocms-laravel-element
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.4
+- alias: expose
+  name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.89
+- alias: cleanup
+  name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
-  alias: cleanup
+  version: 2.3.89


### PR DESCRIPTION
Promote cargocms-laravel-element to version 0.0.4