### PR TITLE
cargocms-laravel-element to 0.0.46

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: cargocms-laravel-element
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.45
+  version: 0.0.46
 - alias: expose
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io


### PR DESCRIPTION
Promote cargocms-laravel-element to version 0.0.46